### PR TITLE
Fixed recipe validation issues, added automated validation

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,20 @@
+[flake8]
+select = B,C,E,F,P,W,B9
+max-line-length = 88
+extend-ignore = E203, W503, F401
+
+### DEFAULT IGNORES FOR 4-space INDENTED PROJECTS ###
+# E127, E128 are hard to silence in certain nested formatting situations.
+# E203 doesn't work for slicing
+# E265, E266 talk about comment formatting which is too opinionated.
+# E402 warns on imports coming after statements. There are important use cases
+# that require statements before imports.
+# E501 is not flexible enough, we're using B950 instead.
+# E722 is a duplicate of B001.
+# P207 is a duplicate of B003.
+# P208 is a duplicate of C403.
+# W503 talks about operator formatting which is too opinionated.
+ignore = E127, E128, E203, E265, E266, E402, E501, E722, P207, P208, W503
+
+per-file-ignores =
+    SharedProcessors/BigFixActioner.py:B950

--- a/.github/workflows/plistlint.yaml
+++ b/.github/workflows/plistlint.yaml
@@ -1,0 +1,31 @@
+---
+name: plistlint
+
+on:
+  push:
+    paths:
+      - "**.plist"
+      - "**.recipe"
+      - ".github/workflows/plistlint.yaml"
+  pull_request:
+    paths:
+      - "**.plist"
+      - "**.recipe"
+      - ".github/workflows/plistlint.yaml"
+
+jobs:
+  plistlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install validate-plist-xml
+        run: pip install validate-plist-xml
+
+      - name: Lint Plist files
+        run: python3 -m validate_plist_xml

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,0 +1,15 @@
+---
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - uses: pre-commit/action@v2.0.3

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# MacOS Specific:
+.DS_Store

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: check-autopkg-recipe-list
       - id: check-autopkg-recipes
         # this should technically be com.github.NickETH in the future
-        args: ["--recipe-prefix=com.github.autopkg-win.", "--strict", "--"]
+        args: ["--recipe-prefix=com.github.autopkg-win.", "--"]
       - id: forbid-autopkg-overrides
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@
 # https://github.com/pre-commit/pre-commit-hooks
 repos:
   - repo: https://github.com/homebysix/pre-commit-macadmin
-    rev: v1.10.1
+    rev: v1.12.3
     hooks:
       - id: check-autopkg-recipe-list
       - id: check-autopkg-recipes

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,8 +29,7 @@ repos:
       #   # exclude plists:
       #   exclude: "*.recipe"
       - id: requirements-txt-fixer
-      - id: trailing-whitespace
-      #  args: [--markdown-linebreak-ext=md]
+      # - id: trailing-whitespace
       - id: detect-private-key
       # - id: no-commit-to-branch
       #   args: [--branch, main]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,55 @@
+---
+# run on only items staged in git:  pre-commit
+# automatically run on commit:      pre-commit install
+# check all files in repo:          pre-commit run --all-files
+# https://github.com/pre-commit/pre-commit-hooks
+repos:
+  - repo: https://github.com/homebysix/pre-commit-macadmin
+    rev: v1.10.1
+    hooks:
+      - id: check-autopkg-recipe-list
+      - id: check-autopkg-recipes
+        # this should technically be com.github.NickETH in the future
+        args: ["--recipe-prefix=com.github.autopkg-win.", "--strict", "--"]
+      - id: forbid-autopkg-overrides
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.0.1
+    hooks:
+      - id: check-yaml
+      # check-json doesn't work with json with comments
+      # - id: check-json
+      - id: check-added-large-files
+        args: ["--maxkb=500"]
+      - id: check-ast
+      - id: check-case-conflict
+      - id: check-merge-conflict
+      # - id: check-xml
+      - id: end-of-file-fixer
+        exclude: "\\.templates/\\.partials/.*"
+      # https://www.aleksandrhovhannisyan.com/blog/crlf-vs-lf-normalizing-line-endings-in-git/
+      # - id: mixed-line-ending
+      #   args: ['--fix=no']
+      - id: requirements-txt-fixer
+      - id: trailing-whitespace
+      #  args: [--markdown-linebreak-ext=md]
+      - id: detect-private-key
+      # - id: no-commit-to-branch
+      #   args: [--branch, main]
+  - repo: https://github.com/adrienverge/yamllint.git
+    rev: v1.26.3
+    hooks:
+      - id: yamllint
+        args: [-c=.yamllint.yaml]
+  - repo: https://github.com/pre-commit/mirrors-isort
+    rev: v5.9.3
+    hooks:
+      - id: isort
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.9.2
+    hooks:
+      - id: flake8
+  # this works with json with comments, but gave me an error
+  # - repo: https://gitlab.com/bmares/check-json5
+  #   rev: v1.0.0
+  #   hooks:
+  #     - id: check-json5

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,11 +24,10 @@ repos:
       - id: check-case-conflict
       - id: check-merge-conflict
       # - id: check-xml
-      - id: end-of-file-fixer
-        exclude: "\\.templates/\\.partials/.*"
-      # https://www.aleksandrhovhannisyan.com/blog/crlf-vs-lf-normalizing-line-endings-in-git/
-      # - id: mixed-line-ending
-      #   args: ['--fix=no']
+      # - id: end-of-file-fixer
+      #   # exclude: "\\.templates/\\.partials/.*"
+      #   # exclude plists:
+      #   exclude: "*.recipe"
       - id: requirements-txt-fixer
       - id: trailing-whitespace
       #  args: [--markdown-linebreak-ext=md]
@@ -40,14 +39,16 @@ repos:
     hooks:
       - id: yamllint
         args: [-c=.yamllint.yaml]
-  - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.9.3
-    hooks:
-      - id: isort
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.2
-    hooks:
-      - id: flake8
+
+  # - repo: https://github.com/pre-commit/mirrors-isort
+  #   rev: v5.9.3
+  #   hooks:
+  #     - id: isort
+  # - repo: https://gitlab.com/pycqa/flake8
+  #   rev: 3.9.2
+  #   hooks:
+  #     - id: flake8
+
   # this works with json with comments, but gave me an error
   # - repo: https://gitlab.com/bmares/check-json5
   #   rev: v1.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: check-autopkg-recipe-list
       - id: check-autopkg-recipes
         # this should technically be com.github.NickETH in the future
-        args: ["--recipe-prefix=com.github.autopkg-win.", "--"]
+        args: ["--recipe-prefix=com.github.autopkg-win."]
       - id: forbid-autopkg-overrides
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.0.1

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,14 @@
+---
+
+extends: default
+
+rules:
+  # for some reason my github actions YAML trip this one but I don't understand why
+  truthy:
+    level: warning
+  # 88 chars should be enough, but don't fail if a line is longer
+  line-length:
+    max: 88
+    level: warning
+  new-lines:
+    level: warning

--- a/Bitwarden/BitwardenDesktop-Win64.download.recipe
+++ b/Bitwarden/BitwardenDesktop-Win64.download.recipe
@@ -55,6 +55,10 @@
         </dict> -->
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>StopProcessingIf</string>
             <key>Arguments</key>
             <dict>

--- a/Enpass/Enpass-Win.build.recipe
+++ b/Enpass/Enpass-Win.build.recipe
@@ -73,7 +73,7 @@
                 <string>%BUILD_DIR%\%pkg_dir%\sourcepkt</string>
                 <key>cmdline_args</key>
 				<array>
-					<string><string>%pathname%</string></string>
+					<string>%pathname%</string>
                     <string>-x</string>
 					<string>%BUILD_DIR%\%pkg_dir%\sourceunzipped"</string>
 				</array>

--- a/Google/GoogleSync-Win64.build/zzTest_GoogleSyncMSI-Win64.download.recipe
+++ b/Google/GoogleSync-Win64.build/zzTest_GoogleSyncMSI-Win64.download.recipe
@@ -9,7 +9,7 @@ LibreOffice Still is the stable version that has undergone more testing (over a 
 LibreOffice Fresh is the stable version with the most recent features. Users interested in taking advantage of our most innovative features should download and use our fresh version.</string>
 	<key>Identifier</key>
 	<!-- <string>io.github.hjuutilainen.download.LibreOffice</string> -->
-	<string>com.github.autopkg-win.download.LibreOffice-Win</string>
+	<string>com.github.autopkg-win.download.GoogleSyncMSI-Win64</string>
 	<key>Input</key>
 	<dict>
 		<key>NAME</key>

--- a/Inkscape/Inkscape-Win64.build.recipe
+++ b/Inkscape/Inkscape-Win64.build.recipe
@@ -5,7 +5,7 @@
     <key>Description</key>
     <string>Alters latest Inkscape MSI-file for Windows.</string>
     <key>Identifier</key>
-    <string>ch.ethz.gitlab.id-cd-win.build.Inkscape-Win64</string>
+    <string>com.github.autopkg-win.build.Inkscape-Win64</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>

--- a/Jabref/Jabref-Win.build.recipe
+++ b/Jabref/Jabref-Win.build.recipe
@@ -5,7 +5,7 @@
     <key>Description</key>
     <string>Alters latest Jabref MSI-file for Windows.</string>
     <key>Identifier</key>
-    <string>ch.ethz.gitlab.id-cd-win.build.Jabref-Win</string>
+    <string>com.github.autopkg-win.build.Jabref-Win</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>

--- a/LibreOffice/LibreOffice-Win64.build.recipe
+++ b/LibreOffice/LibreOffice-Win64.build.recipe
@@ -5,7 +5,7 @@
     <key>Description</key>
     <string>Alters latest LibreOffice MSI-file for Windows.</string>
     <key>Identifier</key>
-    <string>ch.ethz.gitlab.id-cd-win.build.LibreOffice-Win64</string>
+    <string>com.github.autopkg-win.build.LibreOffice-Win64</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>

--- a/Mozilla/Thunderbird-Win64.build.recipe
+++ b/Mozilla/Thunderbird-Win64.build.recipe
@@ -171,7 +171,6 @@
 			<string>Integrate Addons into the install. Enable Sideloading in omni.ja</string>
             <key>Arguments</key>
             <dict>
-			application_name
 				<key>application_name</key>
                 <string>Mozilla Thunderbird</string>
                 <key>install_exe</key>

--- a/NotepadPlusPlus/NotepadPlusPlus-Win64.build.recipe
+++ b/NotepadPlusPlus/NotepadPlusPlus-Win64.build.recipe
@@ -426,6 +426,10 @@
             <key>Processor</key>
             <string>com.github.autopkg-win.SharedProcessors/DateTimeStamps</string>
         </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
 	</array>
 </dict>
 </plist>

--- a/OBS/OBS-Studio-Win64.download.recipe
+++ b/OBS/OBS-Studio-Win64.download.recipe
@@ -55,6 +55,10 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>StopProcessingIf</string>
             <key>Arguments</key>
             <dict>

--- a/Python/Python-Win64.download.recipe
+++ b/Python/Python-Win64.download.recipe
@@ -57,6 +57,10 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>StopProcessingIf</string>
             <key>Arguments</key>
             <dict>

--- a/WinMerge/WinMerge-Win64.download.recipe
+++ b/WinMerge/WinMerge-Win64.download.recipe
@@ -65,6 +65,10 @@
                 <string>E=winmergejp@gmail.com, CN=Takashi Sawanaka, O=Takashi Sawanaka, S=Chiba, C=JP</string>
             </dict>
         </dict>
+		<dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>StopProcessingIf</string>


### PR DESCRIPTION
I added automated validation using github actions. The same validations can be triggered through pre-commit directly. (except for plistlint which I need to build a pre-commit for)

I fixed many validation errors in a bunch of recipes.

WARNING: a few of the recipes had bad identifiers which I corrected, but this means these recipes will fail if the old identifiers are referenced in other things. There should be less than 10 total of these cases, and none of them were download recipes I think, so they shouldn't be referenced within any other recipes in the repo as far as I can tell.

Actually, the identifier changes are specifically in these:

- Google/GoogleSync-Win64.build/zzTest_GoogleSyncMSI-Win64.download.recipe
- Inkscape/Inkscape-Win64.build.recipe
- Jabref/Jabref-Win.build.recipe
- LibreOffice/LibreOffice-Win64.build.recipe

Only these 4 recipes have changes that may require updates to things that reference them down stream.

Once this PR is merged, I'm curious to experiment with this project to see how it converts recipes from plists to YAML: https://github.com/grahampugh/plist-yaml-plist 

I'm also curious if I can figure out a good way to automate the testing of autopkg recipes generically and only the ones that changed.